### PR TITLE
1.0.12

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,8 +32,8 @@ fun getKeystoreProperties(): Properties? {
     return properties
 }
 
-val tagName = "1.0.11"
-val tagCode = 1011
+val tagName = "1.0.12"
+val tagCode = 1012
 
 android {
     namespace = "com.kieronquinn.app.utag"

--- a/app/src/main/java/com/kieronquinn/app/utag/Application.kt
+++ b/app/src/main/java/com/kieronquinn/app/utag/Application.kt
@@ -369,7 +369,7 @@ class Application: Application(), LifecycleEventObserver {
         viewModel<SetupPermissionsViewModel> { SetupPermissionsViewModelImpl(get(), get(), get(), get(), get(), get()) }
         viewModel<SetupChaserViewModel> { SetupChaserViewModelImpl(get(), get()) }
         viewModel<SetupUtsViewModel> { SetupUtsViewModelImpl(get(), get()) }
-        viewModel<SetupAccountViewModel> { SetupAccountViewModelImpl(get(), get()) }
+        viewModel<SetupAccountViewModel> { SetupAccountViewModelImpl(get(), get(), get()) }
         viewModel<AuthResponseViewModel> { AuthResponseViewModelImpl(get(), get()) }
         viewModel<TagRootViewModel> { TagRootViewModelImpl(get(), get()) }
         viewModel<TagMapViewModel> { deviceId ->

--- a/app/src/main/java/com/kieronquinn/app/utag/networking/model/smartthings/GetDevicesResponse.kt
+++ b/app/src/main/java/com/kieronquinn/app/utag/networking/model/smartthings/GetDevicesResponse.kt
@@ -4,5 +4,19 @@ import com.google.gson.annotations.SerializedName
 
 data class GetDevicesResponse(
     @SerializedName("items")
-    val items: List<GetDeviceResponse>
-)
+    val items: List<GetDeviceResponse>,
+    @SerializedName("_links")
+    val links: Links
+) {
+    data class Links(
+        @SerializedName("next")
+        val next: Link?,
+        @SerializedName("previous")
+        val previous: Link?
+    ) {
+        data class Link(
+            @SerializedName("href")
+            val href: String
+        )
+    }
+}

--- a/app/src/main/java/com/kieronquinn/app/utag/networking/services/DeviceService.kt
+++ b/app/src/main/java/com/kieronquinn/app/utag/networking/services/DeviceService.kt
@@ -8,11 +8,13 @@ import retrofit2.Call
 import retrofit2.Retrofit
 import retrofit2.http.GET
 import retrofit2.http.Path
+import retrofit2.http.Url
 
 interface DeviceService {
 
     companion object {
         private const val BASE_URL = "https://client.smartthings.com/"
+        const val GET_DEVICES_URL = "${BASE_URL}devices?includeAllowedActions=true&includeMfuLocations=true&includeUserDevices=false&excludeLocationDevices=false&includeGroups=true&includeHidden=true&exclusiveToHidden=false"
 
         fun createService(context: Context, retrofit: Retrofit): DeviceService {
             return retrofit.newBuilder()
@@ -23,8 +25,8 @@ interface DeviceService {
         }
     }
 
-    @GET("devices?includeAllowedActions=true&includeMfuLocations=true&includeUserDevices=false&excludeLocationDevices=false&includeGroups=true&includeHidden=true&exclusiveToHidden=false")
-    fun getDevices(): Call<GetDevicesResponse>
+    @GET
+    fun getDevices(@Url url: String): Call<GetDevicesResponse>
 
     @GET("devices/{deviceId}")
     fun getDevice(@Path("deviceId") deviceId: String): Call<GetDeviceResponse>

--- a/app/src/main/java/com/kieronquinn/app/utag/repositories/EncryptedSettingsRepository.kt
+++ b/app/src/main/java/com/kieronquinn/app/utag/repositories/EncryptedSettingsRepository.kt
@@ -186,6 +186,15 @@ interface EncryptedSettingsRepository: BaseSettingsRepository {
     val overmatureOfflinePreventionEnabled: UTagSetting<Boolean>
 
     /**
+     *  Android 16+
+     *
+     *  Allow non-launchers to access encrypted files for widgets, since it's no longer possible
+     *  to detect which apps are using them automatically.
+     */
+    @IgnoreInBackup
+    val allowNonLauncherWidgets: UTagSetting<Boolean>
+
+    /**
      *  The encryption key used to encrypt sensitive data stored in the Room database.
      */
     fun getDatabaseEncryptionKey(): SecretKey
@@ -342,6 +351,9 @@ class EncryptedSettingsRepositoryImpl(
 
         private const val KEY_OVERMATURE_OFFLINE_PREVENTION = "overmature_offline_prevention"
         private const val DEFAULT_OVERMATURE_OFFLINE_PREVENTION = true
+
+        private const val KEY_ALLOW_NON_LAUNCHERS = "allow_non_launchers"
+        private const val DEFAULT_ALLOW_NON_LAUNCHERS = false
     }
 
     override val authServerUrl = string(KEY_AUTH_SERVER_URL, "")
@@ -419,6 +431,11 @@ class EncryptedSettingsRepositoryImpl(
     override val overmatureOfflinePreventionEnabled = boolean(
         KEY_OVERMATURE_OFFLINE_PREVENTION,
         DEFAULT_OVERMATURE_OFFLINE_PREVENTION
+    )
+
+    override val allowNonLauncherWidgets = boolean(
+        KEY_ALLOW_NON_LAUNCHERS,
+        DEFAULT_ALLOW_NON_LAUNCHERS
     )
 
     private val encryptionKey = string(KEY_ENCRYPTION_KEY, "")

--- a/app/src/main/java/com/kieronquinn/app/utag/repositories/GeocoderRepository.kt
+++ b/app/src/main/java/com/kieronquinn/app/utag/repositories/GeocoderRepository.kt
@@ -50,9 +50,10 @@ class GeocoderRepositoryImpl(
         val format: String.() -> String? = {
             if(firstLineOnly) firstLineOrNull() else this
         }
-        return (getCachedAddressOrNull(roundedLocation) ?: context.geocode(location)?.merge()?.also {
-            cacheAddress(roundedLocation, it)
-        })?.format()
+        return (getCachedAddressOrNull(roundedLocation) ?: context.geocode(location)
+            ?.merge(location)
+            ?.also { cacheAddress(roundedLocation, it) })
+            ?.format()
     }
 
     override suspend fun clearCache() {

--- a/app/src/main/java/com/kieronquinn/app/utag/repositories/SmartTagRepository.kt
+++ b/app/src/main/java/com/kieronquinn/app/utag/repositories/SmartTagRepository.kt
@@ -8,16 +8,17 @@ import android.util.Base64
 import com.google.android.gms.maps.model.LatLng
 import com.kieronquinn.app.smartspacer.sdk.provider.SmartspacerComplicationProvider
 import com.kieronquinn.app.utag.BuildConfig
-import com.kieronquinn.app.utag.components.bluetooth.ConnectedTagConnection
 import com.kieronquinn.app.utag.components.bluetooth.RemoteTagConnection
 import com.kieronquinn.app.utag.model.BatteryLevel
 import com.kieronquinn.app.utag.model.ChaserRegion
 import com.kieronquinn.app.utag.model.DeviceInfo
 import com.kieronquinn.app.utag.model.EncryptedValue
+import com.kieronquinn.app.utag.model.GeoLocation
 import com.kieronquinn.app.utag.model.database.UTagDatabase
 import com.kieronquinn.app.utag.providers.ConnectedSmartspacerComplication
 import com.kieronquinn.app.utag.repositories.ApiRepository.GetLocationResult
 import com.kieronquinn.app.utag.repositories.SmartTagRepository.Companion.ACTION_REFRESH_TAG_STATES
+import com.kieronquinn.app.utag.repositories.SmartTagRepository.Companion.refreshTagStates
 import com.kieronquinn.app.utag.repositories.SmartTagRepository.TagData
 import com.kieronquinn.app.utag.repositories.SmartTagRepository.TagState
 import com.kieronquinn.app.utag.repositories.SmartTagRepository.TagState.Loaded.LocationState
@@ -162,6 +163,7 @@ interface SmartTagRepository: RoomEncryptionFailedCallback {
                     val address: String?,
                     val time: Long,
                     val isEncrypted: Boolean,
+                    val geoLocation: GeoLocation,
                     override val cached: Boolean
                 ): LocationState(cached)
                 data class PINRequired(
@@ -400,7 +402,14 @@ class SmartTagRepositoryImpl(
                 is GetLocationResult.Location -> {
                     val latLng = LatLng(it.location.latitude, it.location.longitude)
                     val address = geocoderRepository.geocode(latLng)
-                    Location(latLng, address, it.location.time, it.isEncrypted, it.cached)
+                    Location(
+                        latLng,
+                        address,
+                        it.location.time,
+                        it.isEncrypted,
+                        it.location,
+                        it.cached
+                    )
                 }
                 is GetLocationResult.PINRequired -> {
                     LocationState.PINRequired(it.time, it.cached)

--- a/app/src/main/java/com/kieronquinn/app/utag/repositories/WidgetRepository.kt
+++ b/app/src/main/java/com/kieronquinn/app/utag/repositories/WidgetRepository.kt
@@ -14,7 +14,6 @@ import com.google.android.gms.maps.model.BitmapDescriptorFactory
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.MarkerOptions
 import com.kieronquinn.app.utag.Application.Companion.isMainProcess
-import com.kieronquinn.app.utag.BuildConfig
 import com.kieronquinn.app.utag.R
 import com.kieronquinn.app.utag.model.EncryptedValueConverter.ENCRYPTION_TRANSFORMATION
 import com.kieronquinn.app.utag.model.database.UTagDatabase
@@ -37,7 +36,6 @@ import com.kieronquinn.app.utag.utils.extensions.toEncryptedValue
 import com.kieronquinn.app.utag.utils.extensions.toStringSet
 import com.kieronquinn.app.utag.utils.room.RoomEncryptionHelper.RoomEncryptionFailedCallback
 import com.kieronquinn.app.utag.xposed.extensions.TagActivity_createIntent
-import com.kieronquinn.app.utag.xposed.extensions.applySecurity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.Flow

--- a/app/src/main/java/com/kieronquinn/app/utag/ui/screens/settings/location/SettingsLocationFragment.kt
+++ b/app/src/main/java/com/kieronquinn/app/utag/ui/screens/settings/location/SettingsLocationFragment.kt
@@ -3,6 +3,7 @@ package com.kieronquinn.app.utag.ui.screens.settings.location
 import android.icu.util.LocaleData
 import android.icu.util.LocaleData.MeasurementSystem
 import android.icu.util.ULocale
+import android.os.Build
 import android.os.Bundle
 import android.view.View
 import androidx.preference.PreferenceGroup
@@ -231,6 +232,14 @@ class SettingsLocationFragment: BaseSettingsFragment(), BackAvailable {
                     state.period != WidgetRefreshPeriod.NEVER
             isEnabled = state.available && state.period != WidgetRefreshPeriod.NEVER
             onChange<Boolean> { viewModel.onWidgetBatterySaverChanged(it) }
+        }
+        if(Build.VERSION.SDK_INT >= 36) {
+            switchPreference {
+                title = getString(R.string.settings_location_widget_allow_non_launcher_title)
+                summary = getText(R.string.settings_location_widget_allow_non_launcher_content)
+                isChecked = state.allowNonLauncherWidgets
+                onChange<Boolean> { viewModel.onAllowNonLauncherWidgetsChanged(it) }
+            }
         }
     }
     

--- a/app/src/main/java/com/kieronquinn/app/utag/ui/screens/settings/location/SettingsLocationViewModel.kt
+++ b/app/src/main/java/com/kieronquinn/app/utag/ui/screens/settings/location/SettingsLocationViewModel.kt
@@ -41,6 +41,7 @@ abstract class SettingsLocationViewModel: ViewModel() {
     abstract fun onWidgetPeriodClicked()
     abstract fun onWidgetPeriodChanged(period: WidgetRefreshPeriod)
     abstract fun onWidgetBatterySaverChanged(enabled: Boolean)
+    abstract fun onAllowNonLauncherWidgetsChanged(enabled: Boolean)
     abstract fun onUseUwbChanged(enabled: Boolean)
     abstract fun onAllowLongDistanceUwbChanged(enabled: Boolean)
     abstract fun onUnitsChanged(units: Units)
@@ -73,7 +74,8 @@ abstract class SettingsLocationViewModel: ViewModel() {
     data class WidgetSettings(
         val available: Boolean,
         val period: WidgetRefreshPeriod,
-        val batterySaver: Boolean
+        val batterySaver: Boolean,
+        val allowNonLauncherWidgets: Boolean
     )
 
     data class ChaserSettings(
@@ -108,6 +110,7 @@ class SettingsLocationViewModelImpl(
     private val widgetBatterySaver = encryptedSettingsRepository.widgetRefreshOnBatterySaver
     private val chaserEnabled = encryptedSettingsRepository.networkContributionsEnabled
     private val utsEnabled = encryptedSettingsRepository.utsScanEnabled
+    private val allowNonLauncherWidgets = encryptedSettingsRepository.allowNonLauncherWidgets
 
     private val chaserAvailable = chaserRepository.certificate.filterNotNull().map {
         it is ChaserCertificate.Certificate
@@ -149,9 +152,15 @@ class SettingsLocationViewModelImpl(
         widgetRepository.hasWidgets(),
         historyWidgetRepository.hasWidgets(),
         widgetPeriod.asFlow(),
-        widgetBatterySaver.asFlow()
-    ) { hasWidgets, hasHistoryWidgets, period, batterySaver ->
-        WidgetSettings(hasWidgets || hasHistoryWidgets, period, batterySaver)
+        widgetBatterySaver.asFlow(),
+        allowNonLauncherWidgets.asFlow()
+    ) { hasWidgets, hasHistoryWidgets, period, batterySaver, allowNonLauncherWidgets ->
+        WidgetSettings(
+            hasWidgets || hasHistoryWidgets,
+            period,
+            batterySaver,
+            allowNonLauncherWidgets
+        )
     }
 
     override val state = combine(
@@ -272,6 +281,12 @@ class SettingsLocationViewModelImpl(
     override fun onWidgetBatterySaverChanged(enabled: Boolean) {
         viewModelScope.launch {
             widgetBatterySaver.set(enabled)
+        }
+    }
+
+    override fun onAllowNonLauncherWidgetsChanged(enabled: Boolean) {
+        viewModelScope.launch {
+            allowNonLauncherWidgets.set(enabled)
         }
     }
 

--- a/app/src/main/java/com/kieronquinn/app/utag/utils/extensions/Extensions+Context.kt
+++ b/app/src/main/java/com/kieronquinn/app/utag/utils/extensions/Extensions+Context.kt
@@ -277,6 +277,14 @@ private fun PackageManager.getPackageInstallerPackageName(): String? {
         ?.packageName
 }
 
+fun PackageManager.getLauncherPackageName(): String? {
+    val launcherIntent = Intent(Intent.ACTION_MAIN).apply {
+        addCategory(Intent.CATEGORY_HOME)
+    }
+    return launcherIntent.resolveActivityInfo(this, PackageManager.MATCH_DEFAULT_ONLY)
+        ?.packageName
+}
+
 private fun SensorManager.listener(sensor: Sensor, delay: Long) = callbackFlow<FloatArray> {
     var lastEmission = 0L
     val listener = object : SensorEventListener {

--- a/app/src/main/java/com/kieronquinn/app/utag/utils/extensions/Extensions+CustomTabs.kt
+++ b/app/src/main/java/com/kieronquinn/app/utag/utils/extensions/Extensions+CustomTabs.kt
@@ -1,10 +1,21 @@
 package com.kieronquinn.app.utag.utils.extensions
 
 import android.content.Intent
-import android.net.Uri
+import android.content.pm.PackageManager
 import androidx.browser.customtabs.CustomTabsIntent
+import androidx.core.net.toUri
+import com.kieronquinn.app.utag.xposed.extensions.isPackageInstalled
 
-fun getAuthIntent(url: String): Intent {
+private const val PACKAGE_CHROME = "com.android.chrome"
+
+private val CHROME_PACKAGES = setOf(
+    PACKAGE_CHROME,
+    "com.chrome.beta",
+    "com.chrome.dev",
+    "com.chrome.canary"
+)
+
+fun getAuthIntent(url: String, forceChrome: Boolean = false): Intent {
     return CustomTabsIntent.Builder().apply {
         setShowTitle(true)
         setShareState(CustomTabsIntent.SHARE_STATE_OFF)
@@ -13,6 +24,19 @@ fun getAuthIntent(url: String): Intent {
     }.build().intent.apply {
         addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY)
         addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS)
-        data = Uri.parse(url)
+        data = url.toUri()
+        if(forceChrome) {
+            setPackage(PACKAGE_CHROME)
+        }
     }
+}
+
+fun Intent.isIntentChrome(packageManager: PackageManager): Boolean {
+    // Edge case: If Chrome is not available (ie. they disabled it), don't prompt the user to use it
+    if(!packageManager.isPackageInstalled(PACKAGE_CHROME)) return true
+    val resolvedPackage = packageManager.resolveActivity(
+        this,
+        PackageManager.MATCH_DEFAULT_ONLY
+    )?.activityInfo?.packageName ?: return false
+    return CHROME_PACKAGES.contains(resolvedPackage)
 }

--- a/app/src/main/res/raw/faq.md
+++ b/app/src/main/res/raw/faq.md
@@ -90,3 +90,7 @@ There's a few things that could cause this:
 This sometimes happens if you're using SmartThings with Xposed (rooted). Clear the data of 
 SmartThings, open it (the mod may take a moment to re-initialise), sign in and then reboot your 
 device. This resets the notification token.
+
+# Why is uTag not available on Google Play or F-Droid?
+uTag requires modifying the SmartThings app and installs an APK to do so, which is not allowed on 
+Google Play or F-Droid.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,6 +74,10 @@
     <string name="account_error_title">Error</string>
     <string name="account_error_content">An error occurred starting the sign in process, please check your connection and try again</string>
     <string name="account_error_try_again">Try again</string>
+    <string name="account_chrome_warning_title">Sign in with Google</string>
+    <string name="account_chrome_warning_content">Due to a Samsung issue, the Sign in with Google option may not work on your browser. If you require this option, please use Chrome to sign in. Otherwise, you can ignore this warning.</string>
+    <string name="account_chrome_warning_use_chrome">Use Chrome</string>
+    <string name="account_chrome_warning_use_ignore">Ignore</string>
 
     <string name="login_response_error_title">Error</string>
     <string name="login_response_error_content">An error occurred finishing the sign in process, please try again</string>
@@ -151,6 +155,8 @@
     <string name="settings_location_widget_period_never_content">Will only refresh when you tap refresh on a widget or a Tag\'s location is updated by uTag</string>
     <string name="settings_location_widget_battery_saver_title">Widget Refresh on Battery Saver</string>
     <string name="settings_location_widget_battery_saver_content">Refresh widgets when Battery Saver is enabled</string>
+    <string name="settings_location_widget_allow_non_launcher_title">Allow Non-Launcher Widgets</string>
+    <string name="settings_location_widget_allow_non_launcher_content">Allow apps that are not your current launcher to use uTag widgets. <b>If you are using a third party app like Lockscreen Widgets and Drawer, enable this option.</b></string>
     <string name="settings_location_category_search_nearby_title">Search Nearby</string>
     <string name="settings_location_uwb_title">Precise Finding</string>
     <string name="settings_location_uwb_content">Use precise finding (UWB) where supported by your Tag.</string>
@@ -339,6 +345,7 @@
     <string name="map_passive_mode_dialog_content_search_nearby">Passive Mode is currently enabled for this Tag, disable it in the \"More\" settings menu to use Search Nearby.\n\n<b>Note:</b> You can re-enable Passive Mode after searching for the Tag.</string>
     <string name="map_offline_dialog_title">Failed to Refresh</string>
     <string name="map_offline_dialog_content">uTag was unable to refresh your Tag\'s location. Check your network connection and try again. You can still view the last known state of your Tag and Bluetooth functionality when near the Tag.</string>
+    <string name="map_debug_info">Latitude: %1s\nLongitude: %1s\nTimestamp: %1s\nAccuracy: %1s\nSpeed: %1s\nRssi: %1s\nBattery: %1s\nMethod: %1s\nFind host: %1s\nNearby: %1s\nOn Demand: %1s\nConnected User ID: %1s\nConnected Device ID: %1s\nD2D Status: %1s\nWas Encrypted: %1s</string>
 
     <!-- Tag Picker -->
     <string name="tag_picker_title">Select Tag</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,6 @@ playServices = "4.4.2"
 playServicesOssPlugin = "0.10.6"
 playServicesOssLibrary = "17.1.0"
 googleMapsSecrets = "2.0.1"
-dexplore = "1.4.5"
 glide = "4.16.0"
 lottie = "6.4.1"
 kotlinDateRange = "1.0.0"
@@ -99,7 +98,6 @@ retrofit-gson = { group = "com.squareup.retrofit2", name = "converter-gson", ver
 play-services-maps = { group = "com.google.android.gms", name = "play-services-maps", version.ref = "playServicesMaps" }
 play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "playServicesLocation" }
 play-services-oss = { group = "com.google.android.gms", name = "play-services-oss-licenses", version.ref = "playServicesOssLibrary" }
-dexplore = { group = "io.github.neonorbit", name = "dexplore", version.ref = "dexplore" }
 glide = { group = "com.github.bumptech.glide", name = "glide", version.ref = "glide" }
 lottie = { group = "com.airbnb.android", name = "lottie", version.ref = "lottie" }
 kotlin-date-range = { group = "me.moallemi.tools", name = "kotlin-date-range", version.ref = "kotlinDateRange" }

--- a/xposed-core/build.gradle.kts
+++ b/xposed-core/build.gradle.kts
@@ -3,8 +3,8 @@ plugins {
     alias(libs.plugins.kotlin.android)
 }
 
-val xposedName = "1.0.10"
-val xposedCode = 1010
+val xposedName = "1.0.11"
+val xposedCode = 1011
 
 android {
     namespace = "com.kieronquinn.app.utag.xposed.core"


### PR DESCRIPTION
- Iterate through all devices in list to support accounts with huge numbers of SmartThings devices
- Relax restrictions on encrypted widget access on Android 16+. The launcher is now allowed, and all other apps can be allowed by enabling an option.
- Added warning to login for Sign in with Google when not using Chrome due to Samsung bug
- Added fallback for Geocoding if the provider does not include address lines, or any data at all
- Added Google Play and F-Droid information to FAQs