### PR TITLE
Update SmartThings.json to v1.0.17 for Wear OS Watch 5 compatibility

### DIFF
--- a/SmartThings.json
+++ b/SmartThings.json
@@ -1,9 +1,9 @@
 {
-   "version": "1.0.16",
-   "version_code": 1016,
+   "version": "1.0.17",
+   "version_code": 1017,
    "download": "https://github.com/KieronQuinn/uTag/releases/download/smartthings/SmartThings.apk",
    "download_alt": "https://github.com/KieronQuinn/uTag/releases/tag/smartthings",
    "download_filename": "SmartThings.apk",
-   "release_notes": "- Updated to SmartThings v1.8.47.24",
+   "release_notes": "- Updated SmartThings mod (v1.8.47.24) with Wear OS Watch 5 compatibility and LSPatch 0.6",
    "file_size": 179671330
 }


### PR DESCRIPTION
This PR updates SmartThings.json to v1.0.17 with release notes for Galaxy Watch / Wear OS SmartThings synchronization compatibility.