### PR TITLE
Use the new UWB Ranging API if SDK >= 36 (fixes GrapheneOS / no Play Services) 

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,7 +37,7 @@ val tagCode = 1017
 
 android {
     namespace = "com.kieronquinn.app.utag"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.kieronquinn.app.utag"
@@ -106,6 +106,10 @@ android {
         generateLocaleConfig = true
     }
     project.tasks.preBuild.dependsOn("fmm")
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    exclude("**/byRounds/**")
 }
 
 /**

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,6 +41,9 @@
     <!-- Required by AndroidX UWB -->
     <uses-permission android:name="android.permission.UWB_RANGING"/>
 
+    <!-- Required by the Android 16 platform ranging API -->
+    <uses-permission android:name="android.permission.RANGING"/>
+
     <application
         android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/kieronquinn/app/utag/repositories/PlatformUwbRepository.kt
+++ b/app/src/main/java/com/kieronquinn/app/utag/repositories/PlatformUwbRepository.kt
@@ -17,10 +17,12 @@ import android.ranging.raw.RawResponderRangingConfig
 import android.ranging.uwb.UwbAddress
 import android.ranging.uwb.UwbComplexChannel
 import android.ranging.uwb.UwbRangingParams
+import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.core.uwb.RangingMeasurement
 import androidx.core.uwb.UwbAddress as JetpackUwbAddress
 import com.google.uwb.support.fira.FiraOpenSessionParams
+import com.kieronquinn.app.utag.BuildConfig
 import com.kieronquinn.app.utag.components.bluetooth.RemoteTagConnection
 import com.kieronquinn.app.utag.components.uwb.UwbConfig
 import com.kieronquinn.app.utag.repositories.UwbRepository.Companion.randomCodeIndex
@@ -36,6 +38,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeoutOrNull
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.math.abs
 import kotlin.coroutines.resume
 
 /**
@@ -70,7 +73,9 @@ class PlatformUwbRepository(private val context: Context): UwbRepository {
         onEnd: () -> Unit
     ): Flow<UwbEvent?> {
         return callbackFlow {
+            debugLog("Starting Android platform UWB ranging")
             val finished = AtomicBoolean(false)
+            var angleUnit = AngleUnit.RADIANS
 
             fun finish(event: UwbEvent, notifyEnd: Boolean = true) {
                 if(!finished.compareAndSet(false, true)) return
@@ -83,18 +88,25 @@ class PlatformUwbRepository(private val context: Context): UwbRepository {
             val localAddress = UwbAddress.createRandomShortAddress()
             val preference = try {
                 config.getParams().toRangingPreference(localAddress)
-            }catch (_: Exception) {
+            }catch (e: Exception) {
+                debugLog("Failed to create ranging preference", e)
                 finish(UwbEvent.Failed(null))
                 return@callbackFlow
             }
 
             val callback = object: RangingSession.Callback {
                 override fun onOpened() {
+                    debugLog("Platform ranging session opened; requesting tag ranging start")
                     launch {
                         val jetpackAddress = JetpackUwbAddress(localAddress.addressBytes)
-                        val didStart = runCatching {
+                        val startResult = runCatching {
                             tagConnection.startRanging(config, jetpackAddress)
-                        }.getOrDefault(false)
+                        }
+                        val didStart = startResult.getOrDefault(false)
+                        startResult.exceptionOrNull()?.let {
+                            debugLog("Tag ranging start threw an exception", it)
+                        }
+                        debugLog("Tag ranging start acknowledged=$didStart")
                         if(didStart) {
                             trySend(UwbEvent.Started)
                         }else{
@@ -104,27 +116,47 @@ class PlatformUwbRepository(private val context: Context): UwbRepository {
                 }
 
                 override fun onOpenFailed(reason: Int) {
+                    debugLog("Platform ranging session failed to open: reason=$reason")
                     finish(UwbEvent.Failed(reason))
                 }
 
-                override fun onStarted(peer: RangingDevice, technology: Int) = Unit
+                override fun onStarted(peer: RangingDevice, technology: Int) {
+                    debugLog("Platform ranging started: technology=$technology")
+                }
 
                 override fun onResults(peer: RangingDevice, data: RangingData) {
                     val distance = data.distance ?: return
+                    if(angleUnit == AngleUnit.RADIANS && data.hasAngleOutsideRadianRange()) {
+                        angleUnit = AngleUnit.DEGREES
+                        debugLog("Raw angle exceeded +/-PI; switching session to degrees mode")
+                    }
+                    if(BuildConfig.DEBUG) {
+                        Log.d(
+                            TAG,
+                            "Raw result: distance=${distance.toDebugString("m")}, " +
+                                    "azimuth=${data.azimuth.toDebugString(angleUnit.label)}, " +
+                                    "elevation=${data.elevation.toDebugString(angleUnit.label)}, " +
+                                    "angleUnit=$angleUnit, " +
+                                    "technology=${data.rangingTechnology}, " +
+                                    "timestampMs=${data.timestampMillis}"
+                        )
+                    }
                     trySend(
                         UwbEvent.Report(
-                            data.azimuth?.toJetpackAngle(),
-                            data.elevation?.toJetpackAngle(),
+                            data.azimuth?.toJetpackAngle(angleUnit),
+                            data.elevation?.toJetpackAngle(angleUnit),
                             RangingMeasurement(distance.measurement.toFloat())
                         )
                     )
                 }
 
                 override fun onStopped(peer: RangingDevice, technology: Int) {
+                    debugLog("Platform ranging stopped: technology=$technology")
                     finish(UwbEvent.Ended)
                 }
 
                 override fun onClosed(reason: Int) {
+                    debugLog("Platform ranging session closed: reason=$reason")
                     if(reason == RangingSession.Callback.REASON_LOCAL_REQUEST) {
                         finished.compareAndSet(false, true)
                         close()
@@ -138,7 +170,8 @@ class PlatformUwbRepository(private val context: Context): UwbRepository {
                 val session = rangingManager.createRangingSession(context.mainExecutor, callback)
                     ?: error("Unable to create ranging session")
                 session.start(preference)
-            }catch (_: Exception) {
+            }catch (e: Exception) {
+                debugLog("Failed to create or start platform ranging session", e)
                 finish(UwbEvent.Failed(null))
                 null
             }
@@ -230,12 +263,45 @@ class PlatformUwbRepository(private val context: Context): UwbRepository {
         ).setSessionConfig(sessionConfig).build()
     }
 
-    private fun android.ranging.RangingMeasurement.toJetpackAngle(): RangingMeasurement {
-        return RangingMeasurement(Math.toRadians(measurement).toFloat())
+    private fun RangingData.hasAngleOutsideRadianRange(): Boolean {
+        return listOfNotNull(azimuth, elevation).any {
+            abs(it.measurement) > Math.PI
+        }
+    }
+
+    private fun android.ranging.RangingMeasurement.toJetpackAngle(
+        angleUnit: AngleUnit
+    ): RangingMeasurement {
+        val radians = when(angleUnit) {
+            AngleUnit.RADIANS -> measurement
+            AngleUnit.DEGREES -> Math.toRadians(measurement)
+        }
+        return RangingMeasurement(radians.toFloat())
+    }
+
+    private fun android.ranging.RangingMeasurement?.toDebugString(unit: String): String {
+        return this?.let {
+            "${it.measurement}$unit (confidence=${it.confidence})"
+        } ?: "null"
+    }
+
+    private fun debugLog(message: String, throwable: Throwable? = null) {
+        if(!BuildConfig.DEBUG) return
+        if(throwable != null) {
+            Log.e(TAG, message, throwable)
+        }else{
+            Log.d(TAG, message)
+        }
     }
 
     companion object {
+        private const val TAG = "uTagUwb"
         private const val CAPABILITIES_TIMEOUT_MILLIS = 2_000L
+    }
+
+    private enum class AngleUnit(val label: String) {
+        RADIANS("rad"),
+        DEGREES("deg")
     }
 
 }

--- a/app/src/main/java/com/kieronquinn/app/utag/repositories/PlatformUwbRepository.kt
+++ b/app/src/main/java/com/kieronquinn/app/utag/repositories/PlatformUwbRepository.kt
@@ -1,0 +1,241 @@
+package com.kieronquinn.app.utag.repositories
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.ranging.DataNotificationConfig
+import android.ranging.RangingCapabilities
+import android.ranging.RangingData
+import android.ranging.RangingDevice
+import android.ranging.RangingManager
+import android.ranging.RangingPreference
+import android.ranging.RangingSession
+import android.ranging.SessionConfig
+import android.ranging.raw.RawRangingDevice
+import android.ranging.raw.RawResponderRangingConfig
+import android.ranging.uwb.UwbAddress
+import android.ranging.uwb.UwbComplexChannel
+import android.ranging.uwb.UwbRangingParams
+import androidx.annotation.RequiresApi
+import androidx.core.uwb.RangingMeasurement
+import androidx.core.uwb.UwbAddress as JetpackUwbAddress
+import com.google.uwb.support.fira.FiraOpenSessionParams
+import com.kieronquinn.app.utag.components.bluetooth.RemoteTagConnection
+import com.kieronquinn.app.utag.components.uwb.UwbConfig
+import com.kieronquinn.app.utag.repositories.UwbRepository.Companion.randomCodeIndex
+import com.kieronquinn.app.utag.repositories.UwbRepository.UwbEvent
+import com.kieronquinn.app.utag.repositories.UwbRepository.UwbState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.coroutines.resume
+
+/**
+ * UWB handling using Android 16's platform ranging API, without a Google Play Services backend.
+ */
+@RequiresApi(36)
+class PlatformUwbRepository(private val context: Context): UwbRepository {
+
+    private val rangingManager = context.getSystemService(RangingManager::class.java)
+    private val uwbScope = MainScope()
+
+    override val permission = Manifest.permission.RANGING
+
+    override suspend fun isUwbAvailable(): Boolean {
+        return context.packageManager.hasSystemFeature(PackageManager.FEATURE_UWB)
+    }
+
+    override suspend fun getUwbState(): UwbState {
+        if(!isUwbAvailable()) return UwbState.UNAVAILABLE
+        return when(getUwbAvailability()) {
+            RangingCapabilities.ENABLED -> UwbState.AVAILABLE
+            RangingCapabilities.DISABLED_REGULATORY,
+            RangingCapabilities.DISABLED_USER,
+            RangingCapabilities.DISABLED_USER_RESTRICTIONS -> UwbState.DISABLED
+            else -> UwbState.UNAVAILABLE
+        }
+    }
+
+    override fun startRanging(
+        scope: CoroutineScope,
+        tagConnection: RemoteTagConnection,
+        onEnd: () -> Unit
+    ): Flow<UwbEvent?> {
+        return callbackFlow {
+            val finished = AtomicBoolean(false)
+
+            fun finish(event: UwbEvent, notifyEnd: Boolean = true) {
+                if(!finished.compareAndSet(false, true)) return
+                if(notifyEnd) onEnd()
+                trySend(event)
+                close()
+            }
+
+            val config = UwbConfig(randomCodeIndex())
+            val localAddress = UwbAddress.createRandomShortAddress()
+            val preference = try {
+                config.getParams().toRangingPreference(localAddress)
+            }catch (_: Exception) {
+                finish(UwbEvent.Failed(null))
+                return@callbackFlow
+            }
+
+            val callback = object: RangingSession.Callback {
+                override fun onOpened() {
+                    launch {
+                        val jetpackAddress = JetpackUwbAddress(localAddress.addressBytes)
+                        val didStart = runCatching {
+                            tagConnection.startRanging(config, jetpackAddress)
+                        }.getOrDefault(false)
+                        if(didStart) {
+                            trySend(UwbEvent.Started)
+                        }else{
+                            finish(UwbEvent.Failed(null))
+                        }
+                    }
+                }
+
+                override fun onOpenFailed(reason: Int) {
+                    finish(UwbEvent.Failed(reason))
+                }
+
+                override fun onStarted(peer: RangingDevice, technology: Int) = Unit
+
+                override fun onResults(peer: RangingDevice, data: RangingData) {
+                    val distance = data.distance ?: return
+                    trySend(
+                        UwbEvent.Report(
+                            data.azimuth?.toJetpackAngle(),
+                            data.elevation?.toJetpackAngle(),
+                            RangingMeasurement(distance.measurement.toFloat())
+                        )
+                    )
+                }
+
+                override fun onStopped(peer: RangingDevice, technology: Int) {
+                    finish(UwbEvent.Ended)
+                }
+
+                override fun onClosed(reason: Int) {
+                    if(reason == RangingSession.Callback.REASON_LOCAL_REQUEST) {
+                        finished.compareAndSet(false, true)
+                        close()
+                    }else{
+                        finish(UwbEvent.Ended)
+                    }
+                }
+            }
+
+            val cancellationSignal = try {
+                val session = rangingManager.createRangingSession(context.mainExecutor, callback)
+                    ?: error("Unable to create ranging session")
+                session.start(preference)
+            }catch (_: Exception) {
+                finish(UwbEvent.Failed(null))
+                null
+            }
+
+            awaitClose {
+                cancellationSignal?.cancel()
+            }
+        }.onCompletion {
+            uwbScope.launch {
+                tagConnection.stopRanging()
+            }
+        }
+    }
+
+    private suspend fun getUwbAvailability(): Int? {
+        return withTimeoutOrNull(CAPABILITIES_TIMEOUT_MILLIS) {
+            suspendCancellableCoroutine { continuation ->
+                val completed = AtomicBoolean(false)
+                lateinit var callback: RangingManager.RangingCapabilitiesCallback
+                callback = RangingManager.RangingCapabilitiesCallback { capabilities ->
+                    if(completed.compareAndSet(false, true)) {
+                        runCatching {
+                            rangingManager.unregisterCapabilitiesCallback(callback)
+                        }
+                        continuation.resume(
+                            capabilities.technologyAvailability[RangingManager.UWB]
+                        )
+                    }
+                }
+                continuation.invokeOnCancellation {
+                    if(completed.compareAndSet(false, true)) {
+                        runCatching {
+                            rangingManager.unregisterCapabilitiesCallback(callback)
+                        }
+                    }
+                }
+                try {
+                    rangingManager.registerCapabilitiesCallback(context.mainExecutor, callback)
+                }catch (_: Exception) {
+                    if(completed.compareAndSet(false, true)) {
+                        continuation.resume(null)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun FiraOpenSessionParams.toRangingPreference(
+        localAddress: UwbAddress
+    ): RangingPreference {
+        val peerAddress = UwbAddress.fromBytes(destAddressList.first().address)
+        val rangingParams = UwbRangingParams.Builder(
+            sessionId,
+            UwbRangingParams.CONFIG_UNICAST_DS_TWR,
+            localAddress,
+            peerAddress
+        ).setComplexChannel(
+            UwbComplexChannel.Builder()
+                .setChannel(channelNumber)
+                .setPreambleIndex(preambleCodeIndex)
+                .build()
+        ).setRangingUpdateRate(
+            RawRangingDevice.UPDATE_RATE_NORMAL
+        ).setSessionKeyInfo(
+            staticStsIV!! + vendorId!!
+        ).setSlotDuration(
+            UwbRangingParams.DURATION_2_MS
+        ).build()
+
+        val rangingDevice = RawRangingDevice.Builder()
+            .setRangingDevice(RangingDevice.Builder().build())
+            .setUwbRangingParams(rangingParams)
+            .build()
+        val rangingConfig = RawResponderRangingConfig.Builder()
+            .setRawRangingDevice(rangingDevice)
+            .build()
+        val sessionConfig = SessionConfig.Builder()
+            .setAngleOfArrivalNeeded(true)
+            .setDataNotificationConfig(
+                DataNotificationConfig.Builder()
+                    .setNotificationConfigType(
+                        DataNotificationConfig.NOTIFICATION_CONFIG_ENABLE
+                    )
+                    .build()
+            ).build()
+        return RangingPreference.Builder(
+            RangingPreference.DEVICE_ROLE_RESPONDER,
+            rangingConfig
+        ).setSessionConfig(sessionConfig).build()
+    }
+
+    private fun android.ranging.RangingMeasurement.toJetpackAngle(): RangingMeasurement {
+        return RangingMeasurement(Math.toRadians(measurement).toFloat())
+    }
+
+    companion object {
+        private const val CAPABILITIES_TIMEOUT_MILLIS = 2_000L
+    }
+
+}

--- a/app/src/main/java/com/kieronquinn/app/utag/repositories/UwbRepository.kt
+++ b/app/src/main/java/com/kieronquinn/app/utag/repositories/UwbRepository.kt
@@ -18,6 +18,9 @@ interface UwbRepository {
         @SuppressLint("NewApi")
         fun getImplementation(context: Context): UwbRepository {
             return when {
+                Build.VERSION.SDK_INT >= 36 -> {
+                    PlatformUwbRepository(context)
+                }
                 Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
                     JetpackUwbRepository(context)
                 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.7.3"
+agp = "8.10.1"
 kotlin = "2.1.0"
 navigation = "2.8.8"
 browser = "1.8.0"


### PR DESCRIPTION
## tldr

Android SDK >=36 has a new UWB Ranging API which works without Google Play Services, therefore switching over fixes Graphene OS. This PR creates a new `PlatformUwbRepository` and automatically switches over to that on `SDK >= 36`. Fully works on Pixel 9 Pro running current GrapheneOS with Samsung SmartTag 2.  

## Long version

uTag's UWB implementation currently goes through AndroidX Core UWB, which on devices with Google Play Services routes to the Google Play Services Nearby UWB backend.

On GrapheneOS, this path is blocked because sandboxed Play Services does not receive the privileged `android.permission.UWB_PRIVILEGED` access that stock Pixel OS gives it.

This is why UWB works on stock Pixels but not on GrapheneOS, as already noted in #243 .

There is now a clean way to avoid that dependency on Android 16+: use the public platform `android.ranging.RangingManager` API directly for UWB ranging.

## Current uTag path

`JetpackUwbRepository` currently uses:

* `androidx.core.uwb.UwbManager`
* `UwbManager.createInstance(context)`
* `controleeSessionScope()`
* `prepareSession(...)`
* app permission `android.permission.UWB_RANGING`

Relevant files:

* [https://github.com/KieronQuinn/uTag/blob/main/app/src/main/java/com/kieronquinn/app/utag/repositories/JetpackUwbRepository.kt](https://github.com/KieronQuinn/uTag/blob/main/app/src/main/java/com/kieronquinn/app/utag/repositories/JetpackUwbRepository.kt)
* [https://github.com/KieronQuinn/uTag/blob/main/app/src/main/java/com/kieronquinn/app/utag/repositories/UwbRepository.kt](https://github.com/KieronQuinn/uTag/blob/main/app/src/main/java/com/kieronquinn/app/utag/repositories/UwbRepository.kt)

uTag currently uses AndroidX UWB `1.0.0-alpha10` and `compileSdk = 35`:

* [https://github.com/KieronQuinn/uTag/blob/main/gradle/libs.versions.toml](https://github.com/KieronQuinn/uTag/blob/main/gradle/libs.versions.toml)
* [https://github.com/KieronQuinn/uTag/blob/main/app/build.gradle.kts](https://github.com/KieronQuinn/uTag/blob/main/app/build.gradle.kts)

## Why GrapheneOS breaks this

GrapheneOS tracks the Play Services UWB limitation here:

[https://github.com/GrapheneOS/os-issue-tracker/issues/4611](https://github.com/GrapheneOS/os-issue-tracker/issues/4611)

The failure seen from Play Services is:

```text
java.lang.SecurityException: UwbService: Neither user ... nor current process has android.permission.UWB_PRIVILEGED
```

GrapheneOS maintainers have confirmed that UWB itself is functional, but sandboxed Play Services currently has no supported way to use its privileged UWB functionality.

There is also an experimental GrapheneOS/GmsCompat patch adding a toggle for `UWB_PRIVILEGED`, but a test still failed at `com.google.android.gms.nearby.uwb.UwbClient.isAvailable()`, suggesting that emulating stock privileged Play Services may require more than just granting that one permission:

* [https://github.com/danimihalca/platform_packages_apps_GmsCompat/commit/68b018aed1b3c74916eb3afdf22b5a8bc22e533c](https://github.com/danimihalca/platform_packages_apps_GmsCompat/commit/68b018aed1b3c74916eb3afdf22b5a8bc22e533c)
* [https://github.com/danimihalca/platform_frameworks_base/commit/956c3a8fcb0f00b5874233898e57b24c10f0d3cc](https://github.com/danimihalca/platform_frameworks_base/commit/956c3a8fcb0f00b5874233898e57b24c10f0d3cc)

## Native `RangingManager` backend on API 36+

Android 16 added the public `android.ranging.RangingManager` API with raw UWB ranging support.

AndroidX Core UWB has already implemented an adapter from its existing `RangingParameters` to `RangingManager` / raw UWB:

* `UwbManagerImpl.kt`
* `UwbClientSessionScopeRangingImpl.kt`
* `UwbControleeSessionScopeRangingImpl.kt`

Current AndroidX source:

[https://github.com/androidx/androidx/tree/androidx-main/core/uwb/uwb/src/main/java/androidx/core/uwb/impl](https://github.com/androidx/androidx/tree/androidx-main/core/uwb/uwb/src/main/java/androidx/core/uwb/impl)

In particular, AndroidX now builds a responder session as:

```text
RangingManager
  -> RawResponderRangingConfig
  -> RawRangingDevice
  -> UwbRangingParams
```

and maps the same parameters uTag already has:

* session ID
* local / peer addresses
* complex channel
* preamble
* key material
* update rate
* slot duration
* AoA

However, AndroidX currently still has:

```kotlin
private const val USE_RANGING_MODULE = false
```

and there doesn't seem to be any indication that they're going to switch over any time soon, so simply updating the dependency does nothing.

## Also, it's almost a drop-in replacement. 

uTag already constructs essentially all the required FiRa parameters in `UwbConfig`:

[https://github.com/KieronQuinn/uTag/blob/main/app/src/main/java/com/kieronquinn/app/utag/components/uwb/UwbConfig.kt](https://github.com/KieronQuinn/uTag/blob/main/app/src/main/java/com/kieronquinn/app/utag/components/uwb/UwbConfig.kt)

These line up closely with what the Android 16 raw UWB API accepts.

GrapheneOS also ships the corresponding Ranging/UWB implementation in AOSP's UWB module, including the privileged backend which holds `UWB_PRIVILEGED` itself:

[https://github.com/GrapheneOS/platform_packages_modules_Uwb/tree/17/ranging](https://github.com/GrapheneOS/platform_packages_modules_Uwb/tree/17/ranging)

Relevant backend manifest:

[https://github.com/GrapheneOS/platform_packages_modules_Uwb/blob/17/ranging/uwb_backend/AndroidManifest.xml](https://github.com/GrapheneOS/platform_packages_modules_Uwb/blob/17/ranging/uwb_backend/AndroidManifest.xml)

## Implementation Shape

A new `PlatformUwbRepository` is alongside `JetpackUwbRepository`, and selected on API 36+: [file](https://github.com/Yandrik/uTag/blob/e80a93b0e8f9cfb42fb4ccc716803cbba3075a83/app/src/main/java/com/kieronquinn/app/utag/repositories/UwbRepository.kt#L21)

This works on my Pixel 9 Pro running Graphene OS right now with my SmartTag 2s. This PR is created with AI assistance, but is fully manually reviewed. I hope this is helpful :) 

Related: #243
