### PR TITLE
Only re-post the ongoing notification when its text actually changes

### DIFF
--- a/app/src/main/java/com/kieronquinn/app/utag/service/UTagForegroundService.kt
+++ b/app/src/main/java/com/kieronquinn/app/utag/service/UTagForegroundService.kt
@@ -236,7 +236,7 @@ class UTagForegroundService: LifecycleService() {
     private var remoteForegroundService: IUTagSmartThingsForegroundService? = null
     private var isDisconnecting = false
     private var isSettingUpSafeAreas = false
-    private var notificationHash: Int? = null
+    private var ongoingNotificationContent: OngoingNotificationContent? = null
 
     private val tagStateChangeBus = MutableStateFlow(System.currentTimeMillis())
     private val safeAreaSetupBus = MutableStateFlow(System.currentTimeMillis())
@@ -482,14 +482,17 @@ class UTagForegroundService: LifecycleService() {
     override fun onCreate() {
         super.onCreate()
         log("Service created")
+        val initialContent = getOngoingNotificationContent(isError = false)
         val notification = notifications.createNotification(NotificationChannel.FOREGROUND_SERVICE) {
-            it.ongoing()
+            it.ongoing(initialContent)
         }
         //Clear any existing error notifications
         notifications.cancelNotification(NotificationId.FOREGROUND_SERVICE_ERROR)
         if (powerManager.isIgnoringBatteryOptimizations(BuildConfig.APPLICATION_ID) &&
             startForeground(NotificationId.FOREGROUND_SERVICE, notification)
         ) {
+            //Remember what was just posted, so the first update does not repeat it
+            ongoingNotificationContent = initialContent
             tryConnectToService()
             tryConnectToForegroundService()
             setupBluetoothReceiver()
@@ -733,14 +736,16 @@ class UTagForegroundService: LifecycleService() {
             delay(5_000L)
             log("Connecting to service (attempt 2)")
             if(!connectToService()) {
-                //Clear the hash so retry immediately shows the regular notification
-                notificationHash = null
+                //Record the error text, so a repeated failure does not post the same notification
+                //again, but a successful retry still restores the regular one
+                val errorContent = getOngoingNotificationContent(isError = true)
+                ongoingNotificationContent = errorContent
                 //Update the ongoing notification
                 notifications.showNotification(
                     NotificationId.FOREGROUND_SERVICE,
                     NotificationChannel.FOREGROUND_SERVICE
                 ) {
-                    it.ongoing(isError = true)
+                    it.ongoing(errorContent, isError = true)
                 }
                 //Also show a higher priority error notification
                 notifications.showNotification(
@@ -1012,7 +1017,9 @@ class UTagForegroundService: LifecycleService() {
             knownTagNames.filterNotNull(),
             passiveModeRepository.passiveModeConfigs
         ) { knownTagNames, _ ->
-            updateNotification(true)
+            //A renamed Tag, or one entering or leaving passive mode, changes the notification text,
+            //which updateNotification now detects on its own
+            updateNotification()
             if(knownTagNames.isEmpty() && !hasTriedToLoadDeviceIds) {
                 hasTriedToLoadDeviceIds = true
                 deviceRepository.getDeviceIds()
@@ -1174,15 +1181,30 @@ class UTagForegroundService: LifecycleService() {
         tagDisconnectNotificationJobs.remove(id)
     }
 
-    private fun NotificationCompat.Builder.ongoing(
-        isError: Boolean = false
-    ) = apply {
+    /**
+     *  The text the ongoing notification shows to the user. The notification is only posted again
+     *  when this changes, so a Tag which drops and reconnects into the state it was already in
+     *  does not produce a second, identical notification.
+     */
+    private data class OngoingNotificationContent(
+        val title: String,
+        val content: String?
+    )
+
+    /**
+     *  Works out what the ongoing notification should say. This is the only place the title and
+     *  text are decided, so the value compared in [updateNotification] is always exactly what the
+     *  user would see.
+     */
+    private fun getOngoingNotificationContent(isError: Boolean): OngoingNotificationContent {
         val connectedTags = tagConnections.filterValues { it is ConnectedTagConnection }
         val passiveTags = tagConnections.filterValues { it is ScannedTagConnection }.filterKeys {
             passiveModeRepository.isInPassiveMode(it, ignoreBypass = true)
         }
         val allTags = connectedTags + passiveTags
         val tagCount = allTags.size
+        //Sorted so the same set of Tags always produces the same text. The connections are held in
+        //a ConcurrentHashMap, whose iteration order is not guaranteed to survive a reconnect.
         val tagNames = allTags.entries.mapNotNull {
             //Non-passive scanned states are filtered out above
             val isPassive = it.value is ScannedTagConnection
@@ -1191,11 +1213,7 @@ class UTagForegroundService: LifecycleService() {
                     getString(R.string.notification_title_background_service_passive, name)
                 }else name
             }
-        }
-        val notificationIntent =
-            Intent(this@UTagForegroundService, MainActivity::class.java).apply {
-                addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
-            }
+        }.sorted()
         val title = when {
             isError -> {
                 getString(R.string.notification_title_background_service_error_short)
@@ -1221,8 +1239,29 @@ class UTagForegroundService: LifecycleService() {
             }
             else -> null
         }
+        return OngoingNotificationContent(title, content)
+    }
+
+    /**
+     *  [content] is passed in rather than worked out here, so the text that gets posted is always
+     *  the exact text the caller recorded as current. Working it out again would read the Tag
+     *  connections a second time, which can change in between.
+     */
+    private fun NotificationCompat.Builder.ongoing(
+        content: OngoingNotificationContent,
+        isError: Boolean = false
+    ) = apply {
+        val title = content.title
+        val notificationIntent =
+            Intent(this@UTagForegroundService, MainActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+            }
         setContentTitle(title)
-        setContentText(content)
+        setContentText(content.content)
+        //No effect while the channel is IMPORTANCE_LOW, which emits no sound, vibration or ticker.
+        //It is here because the user can raise the channel's importance in system settings, and the
+        //app never lowers it again. Without this, every Tag connect would then chime.
+        setOnlyAlertOnce(true)
         setSmallIcon(R.drawable.ic_notification)
         setOngoing(true)
         setShowWhen(false)
@@ -1357,6 +1396,8 @@ class UTagForegroundService: LifecycleService() {
         )
         setContentTitle(getString(R.string.notification_title_bluetooth_error))
         setContentText(getString(R.string.notification_content_bluetooth_error))
+        //Shares the ongoing notification's ID and channel, so it gets the same treatment
+        setOnlyAlertOnce(true)
         setSmallIcon(R.drawable.ic_notification_error)
         setOngoing(true)
         setAutoCancel(false)
@@ -1563,24 +1604,31 @@ class UTagForegroundService: LifecycleService() {
         }
     }
 
-    private suspend fun updateNotification(force: Boolean = false) {
-        //Prevent updating the notification if the state hasn't actually changed
+    private suspend fun updateNotification() {
         val bluetoothEnabled = bluetoothEnabled.value.enabled
-        val notificationHash = listOf(tagConnections, bluetoothEnabled).hashCode()
-        if(this.notificationHash != notificationHash || force) {
-            this.notificationHash = notificationHash
-            val bluetoothIntent = if(!bluetoothEnabled) {
-                smartThingsRepository.getEnableBluetoothIntent()
-            }else null
-            notifications.showNotification(
-                NotificationId.FOREGROUND_SERVICE,
-                NotificationChannel.FOREGROUND_SERVICE
-            ) {
-                if(bluetoothEnabled) {
-                    it.ongoing()
-                }else{
-                    it.bluetoothError(bluetoothIntent)
-                }
+        val content = if(bluetoothEnabled) {
+            getOngoingNotificationContent(isError = false)
+        }else{
+            OngoingNotificationContent(
+                getString(R.string.notification_title_bluetooth_error),
+                getString(R.string.notification_content_bluetooth_error)
+            )
+        }
+        //Posting the notification again moves it back to the top of the shade, and brings it back
+        //if the user has dismissed it. Only do that when the text has actually changed.
+        if(ongoingNotificationContent == content) return
+        ongoingNotificationContent = content
+        val bluetoothIntent = if(!bluetoothEnabled) {
+            smartThingsRepository.getEnableBluetoothIntent()
+        }else null
+        notifications.showNotification(
+            NotificationId.FOREGROUND_SERVICE,
+            NotificationChannel.FOREGROUND_SERVICE
+        ) {
+            if(bluetoothEnabled) {
+                it.ongoing(content)
+            }else{
+                it.bluetoothError(bluetoothIntent)
             }
         }
     }


### PR DESCRIPTION
Hi! Thanks for uTag — it's lovely work, and the only reason my SmartTags are useful to me at all. This is my first contribution here, so please do say if anything is off-style, or if you'd rather take a different approach entirely.

## The problem

The ongoing "N Tags connected" notification gets posted again even when nothing the user can see has changed. Since Android 13 lets you dismiss foreground-service notifications, each redundant re-post brings it straight back — so it comes across as the app nagging every few minutes about the same tags.

Measured on a Pixel 9 Pro (Android 17, uTag 1.0.16) before the change: over about 22 minutes, notification id 1 was posted 15 times. Every `notification_canceled` entry in the event log had reason code 2, i.e. me dismissing it. Sampling the notification's extras every 3 seconds, the text never changed once — `1 Tag connected` / `MyLuggage` throughout.

## Cause

The guard meant to prevent this was:

```kotlin
val notificationHash = listOf(tagConnections, bluetoothEnabled).hashCode()
```

`tagConnections` is a `ConcurrentHashMap<String, BaseTagConnection>`, and none of `BaseTagConnection`, `ConnectedTagConnection` or `ScannedTagConnection` override `hashCode()`, so the map hashes its values by identity rather than by what they render to. That makes it fire when a connection object is swapped for an equivalent one, and miss changes that genuinely do alter the text — a rename, or a passive-mode toggle. I think that's also why the `force` parameter had to exist, though you'd know better than me.

## The change

- `getOngoingNotificationContent()` becomes the single place the title and text are decided, returning a small `OngoingNotificationContent(title, content)`.
- `updateNotification()` compares that value and returns early when it is unchanged.
- The `force` parameter is removed. A rename or a passive-mode change now moves the compared value on its own, so the call site no longer needs to override the guard.
- The computed content is passed into the builder rather than recomputed inside it, so what gets posted is always exactly what was recorded as current.
- Tag names are sorted. `ConcurrentHashMap` iteration order isn't guaranteed to survive a reconnect, so the same set of tags could otherwise render in a different order and defeat the comparison. Side effect: the list is now alphabetical.
- `setOnlyAlertOnce(true)` on the two ongoing builders. This has no effect while the channel is `IMPORTANCE_LOW`, but a user can raise a channel's importance and the app never lowers it again. Happy to drop it if you'd rather keep the diff to just the fix.

## Testing

All measurements are from a Pixel 9 Pro on Android 17 with two tags. I've also seen the same behaviour on a Pixel 8a, but I haven't run any measurements on that one.

I built a version that evaluates both the old and the new rule on the same events, acting only on the new one:

| | |
|---|---|
| Calls to `updateNotification()` | 27 |
| Posts the old rule would have made | 19 |
| Posts the new rule made | 4 |
| Identical re-posts suppressed | 15 |

I also checked that changes which *should* update the notification still do, since removing `force` is the riskiest part of this. All verified on-device:

- **Renaming a tag** — renamed in SmartThings, then opened the Tag map so uTag refreshed its device list. The notification had been dismissed nine minutes earlier and had stayed away; it came back within a second of the name changing, showing the new name. That exercises both directions of the guard in one event: quiet while nothing changes, immediate when something does.
- **Toggling passive mode** — `Audi, Luggage` became `Audi, Luggage (Passive)` about five seconds after enabling it, and reverted when disabled.
- Bluetooth off → "Bluetooth Disabled"; back on → "N Tags connected" restored.
- A tag leaving range decrements the count; all tags away → "No Tags connected".
- Dismissing the notification: before the change it came back every time (5 of 5, averaging about 5.6 minutes). With the change it stayed dismissed for 46 minutes, until a tag genuinely changed state.
- The text on screen matched the recorded value at every sample, so the guard isn't suppressing a real change.

The measurements are all from a single device with one pair of tags, so please weigh the breadth accordingly.
